### PR TITLE
Enable self signed certificates #15

### DIFF
--- a/config-generator/src/main/resources/default-config.yaml
+++ b/config-generator/src/main/resources/default-config.yaml
@@ -16,6 +16,7 @@ jgroups:
     recordType: A
 keystore:
   alias: server
+  selfSignCert: false
 xsite:
   masterCandidate: true
 

--- a/config-generator/src/main/resources/infinispan.xml
+++ b/config-generator/src/main/resources/infinispan.xml
@@ -38,11 +38,12 @@
                     <gsp:scriptlet>
                         <![CDATA[
                         if (keystore && keystore.path) {
+                            def selfSignAttr = keystore.selfSignCert ? "localhost" : ""
                         ]]>
                     </gsp:scriptlet>
                     <server-identities>
                         <ssl>
-                            <keystore path="${keystore.path}" keystore-password="${keystore.password}" alias="${keystore.alias}"/>
+                            <keystore path="${keystore.path}" alias="${keystore.alias}" keystore-password="${keystore.password}" generate-self-signed-certificate-host="${selfSignAttr}"/>
                         </ssl>
                     </server-identities>
                     <gsp:scriptlet>


### PR DESCRIPTION
If the user doesn't provide any certificates or keystore and the selfSignCert field is set to true, this add to the infinispan.xml the settings to let the Infinispan server generates a selfsigned keystore.
