### PR TITLE
Configure max_site_masters option for RELAY2

### DIFF
--- a/config-generator/src/main/resources/default-config.yaml
+++ b/config-generator/src/main/resources/default-config.yaml
@@ -24,7 +24,7 @@ keystore:
   type: pkcs12
 xsite:
   masterCandidate: true
-
+  maxSiteMasters: 1
 logging:
   console:
     level: trace

--- a/config-generator/src/main/resources/templates/infinispan.xml
+++ b/config-generator/src/main/resources/templates/infinispan.xml
@@ -1,10 +1,10 @@
 <infinispan
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="urn:infinispan:config:11.0 https://infinispan.org/schemas/infinispan-config-11.0.xsd
-                            urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd"
+                            urn:infinispan:server:11.0 https://infinispan.org/schemas/infinispan-server-11.0.xsd
+                            urn:org:jgroups https://www.jgroups.org/schema/jgroups-4.2.xsd"
         xmlns="urn:infinispan:config:11.0"
-        xmlns:server="urn:infinispan:server:11.0"
-        xmlns:jgroups="urn:org.jgroups">
+        xmlns:server="urn:infinispan:server:11.0">
 
     <jgroups>
         <stack-file name="image-{jgroups.transport}" path="jgroups-{jgroups.transport}.xml"/>
@@ -13,7 +13,7 @@
         <stack-file name="relay-global" path="jgroups-relay.xml"/>
 
         <stack name="xsite" extends="image-{jgroups.transport}">
-            <jgroups:relay.RELAY2 site="{xsite.name}" max_site_masters="1000"
+            <relay.RELAY2 xmlns="urn:org:jgroups" site="{xsite.name}" max_site_masters="{xsite.maxSiteMasters}"
                                   can_become_site_master="{xsite.masterCandidate}"/>
             <remote-sites default-stack="relay-global">
                 <remote-site name="{xsite.name}"/>

--- a/config-generator/src/test/java/org/infinispan/images/AbstractMainTest.java
+++ b/config-generator/src/test/java/org/infinispan/images/AbstractMainTest.java
@@ -284,6 +284,11 @@ abstract class AbstractMainTest {
       infinispan.hasXPath(stack + "/i:remote-sites/i:remote-site[2]")
             .haveAttribute("name", "NYC");
 
+      infinispan.hasXPath(stack + "/j:relay.RELAY2")
+            .haveAttribute("max_site_masters", "8")
+            .haveAttribute("can_become_site_master", "false")
+            .haveAttribute("site", "LON");
+
       XmlAssert relay = jgroupsRelay();
       relay.hasXPath("//j:config/j:TCP")
             .haveAttribute("external_addr", "lon-addr")

--- a/config-generator/src/test/resources/config/jgroups-xsite.yaml
+++ b/config-generator/src/test/resources/config/jgroups-xsite.yaml
@@ -1,6 +1,7 @@
 xsite:
   address: lon-addr
   masterCandidate: false
+  maxSiteMasters: 8
   name: LON
   port: 7200
   backups:


### PR DESCRIPTION
Vittorio's approach requires to have a single site master. Make the attribute configurable.