### PR TITLE
infinispan/infinispan-images#81 Bind the singleport to 127.0.0.1 as d…

### DIFF
--- a/config-generator/src/main/resources/templates/infinispan.xml
+++ b/config-generator/src/main/resources/templates/infinispan.xml
@@ -60,7 +60,7 @@
     <server xmlns="urn:infinispan:server:11.0">
         <interfaces>
             <interface name="public">
-                <inet-address value="{jgroups.bindAddress}"/>
+                <inet-address value="$\{infinispan.bind.address:127.0.0.1\}"/>
             </interface>
         </interfaces>
 


### PR DESCRIPTION
…efault

The bind address can be customised by providing the 'infinispan.bind.address' property at runtime. E.g. -e JAVA_OPTIONS="-Dinfinispan.bind.address=<some-address>"