### PR TITLE
[11.0.x] infinispan/infinispan-images#81 Bind the singleport to jgroups.bindAd…

### DIFF
--- a/config-generator/src/main/resources/templates/infinispan.xml
+++ b/config-generator/src/main/resources/templates/infinispan.xml
@@ -33,7 +33,7 @@
     <server xmlns="urn:infinispan:server:11.0">
         <interfaces>
             <interface name="public">
-                <inet-address value="{jgroups.bindAddress}"/>
+                <inet-address value="$\{infinispan.bind.address:{jgroups.bindAddress}\}"/>
             </interface>
         </interfaces>
 


### PR DESCRIPTION
…dress as default

The bind address can be customised by providing the 'infinispan.bind.address' property at runtime. E.g. -e JAVA_OPTIONS="-Dinfinispan.bind.address=<some-address>"

On hold until 11.0.2