### PR TITLE
Update versions

### DIFF
--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -13,16 +13,14 @@
         <quarkus.package.type>uber-jar</quarkus.package.type>
         <version.assertj>3.14.0</version.assertj>
         <version.bytebuddy>1.10.0</version.bytebuddy>
-        <version.picoli>4.2.0</version.picoli>
         <version.quarkus>1.7.6.Final</version.quarkus>
-        <version.snakeyaml>1.26</version.snakeyaml>
         <version.xmlunit>2.6.4</version.xmlunit>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-universe-bom</artifactId>
+                <artifactId>quarkus-bom</artifactId>
                 <version>${version.quarkus}</version>
                 <type>pom</type>
                 <scope>import</scope>
@@ -37,17 +35,14 @@
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli</artifactId>
-            <version>${version.picoli}</version>
         </dependency>
         <dependency>
             <groupId>info.picocli</groupId>
             <artifactId>picocli-codegen</artifactId>
-            <version>${version.picoli}</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>${version.snakeyaml}</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -11,10 +11,9 @@
     <artifactId>config-generator</artifactId>
     <properties>
         <quarkus.package.type>uber-jar</quarkus.package.type>
-        <version.assertj>3.14.0</version.assertj>
         <version.bytebuddy>1.10.0</version.bytebuddy>
         <version.quarkus>1.7.6.Final</version.quarkus>
-        <version.xmlunit>2.6.4</version.xmlunit>
+        <version.xmlunit>2.8.2</version.xmlunit>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -54,12 +53,6 @@
             <artifactId>byte-buddy</artifactId>
             <version>${version.bytebuddy}</version>
             <scope>test</scope>
-        </dependency>
-        <!-- Explicitly define assertj version to fix XMlUnit issue https://github.com/xmlunit/xmlunit/issues/181-->
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${version.assertj}</version>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>

--- a/config-generator/pom.xml
+++ b/config-generator/pom.xml
@@ -11,7 +11,6 @@
     <artifactId>config-generator</artifactId>
     <properties>
         <quarkus.package.type>uber-jar</quarkus.package.type>
-        <version.bytebuddy>1.10.0</version.bytebuddy>
         <version.quarkus>1.7.6.Final</version.quarkus>
         <version.xmlunit>2.8.2</version.xmlunit>
     </properties>
@@ -46,12 +45,6 @@
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy</artifactId>
-            <version>${version.bytebuddy}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,14 @@
 
     <modelVersion>4.0.0</modelVersion>
 
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>36</version>
+        <!-- to avoid maven searching for ../pom.xml -->
+        <relativePath/>
+    </parent>
+
     <groupId>org.infinispan.images</groupId>
     <artifactId>infinispan-images-parent</artifactId>
     <version>2.1.3-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -79,10 +79,10 @@
         <jboss.releases.repo.url>${jboss.releases.nexus.url}/service/local/staging/deploy/maven2/
         </jboss.releases.repo.url>
 
-        <version.maven.checkstyle.plugin>3.0.0</version.maven.checkstyle.plugin>
+        <version.maven.checkstyle.plugin>3.1.1</version.maven.checkstyle.plugin>
         <version.maven.nexus-staging>1.6.8</version.maven.nexus-staging>
-        <version.maven.source>3.0.1</version.maven.source>
-        <version.maven.surefire>3.0.0-M3</version.maven.surefire>
+        <version.maven.source>3.2.0</version.maven.source>
+        <version.maven.surefire>3.0.0-M5</version.maven.surefire>
     </properties>
 
     <build>


### PR DESCRIPTION
* Removed bytebuddy. It isn't used anywhere.
* Replaced quarkus-universe-bom by quarkus-bom. Makes prod easier
* Upgraded XmlUnit to remove assertJ dependency. The newer version includes the fix.
* Use picocli & snakeyaml from quarkus

edit: aligned the plugins version with Infinispan