### PR TITLE
Set port_range=0 for TCP stack

### DIFF
--- a/config-generator/src/main/resources/templates/infinispan.xml
+++ b/config-generator/src/main/resources/templates/infinispan.xml
@@ -14,7 +14,9 @@
         <stack name="image-tcp" extends="tcp">
             <TCP bind_addr="$\{jgroups.bind.address,jgroups.tcp.address:{jgroups.bindAddress}\}"
                  bind_port="$\{jgroups.bind.port,jgroups.tcp.port:7800\}"
-                 enable_diagnostics="{jgroups.diagnostics}"/>
+                 enable_diagnostics="{jgroups.diagnostics}"
+                 port_range="0"
+            />
 
             {#if jgroups.dnsPing.query}
             <dns.DNS_PING dns_address="{jgroups.dnsPing.address}" dns_query="{jgroups.dnsPing.query}"


### PR DESCRIPTION
The TCP stack does not have `port_range="0"` set and the `DNS_PING` is trying 10 different ports per IP by default. 