### PR TITLE
Allow configure bind address and port for cross-site

### DIFF
--- a/config-generator/src/main/resources/default-config.yaml
+++ b/config-generator/src/main/resources/default-config.yaml
@@ -23,9 +23,12 @@ jgroups:
   diagnostics: false
   encrypt: false
   transport: tcp
+  bindPort: 7800
   dnsPing:
     address: ""
     recordType: A
+  relay:
+    bindPort: 7900
 keystore:
   alias: server
   selfSignCert: false

--- a/config-generator/src/main/resources/templates/infinispan.xml
+++ b/config-generator/src/main/resources/templates/infinispan.xml
@@ -13,7 +13,7 @@
     <jgroups>
         <stack name="image-tcp" extends="tcp">
             <TCP bind_addr="$\{jgroups.bind.address,jgroups.tcp.address:{jgroups.bindAddress}\}"
-                 bind_port="$\{jgroups.bind.port,jgroups.tcp.port:7800\}"
+                 bind_port="$\{jgroups.bind.port,jgroups.tcp.port:{jgroups.bindPort}\}"
                  enable_diagnostics="{jgroups.diagnostics}"
                  port_range="0"
             />

--- a/config-generator/src/main/resources/templates/jgroups-relay.xml
+++ b/config-generator/src/main/resources/templates/jgroups-relay.xml
@@ -4,8 +4,8 @@
 >
 
     {#if 'TUNNEL' == xsite.transport.upperCase()}
-    <TUNNEL bind_addr="{jgroups.bindAddress}"
-            bind_port="7900"
+    <TUNNEL bind_addr="$\{jgroups.relay.bind.address:{jgroups.bindAddress}\}"
+            bind_port="$\{jgroups.relay.bind.port:{jgroups.relay.bindPort}\}"
             enable_diagnostics="{jgroups.diagnostics}"
             port_range="0"
             gossip_router_hosts="{xsite.address}[{xsite.port}],{remoteSites}"
@@ -13,8 +13,8 @@
 
     <PING return_entire_cache="true"/>
     {#else}
-    <TCP bind_addr="{jgroups.bindAddress}"
-         bind_port="7900"
+    <TCP bind_addr="$\{jgroups.relay.bind.address:{jgroups.bindAddress}\}"
+         bind_port="$\{jgroups.relay.bind.port:{jgroups.relay.bindPort}\}"
          enable_diagnostics="{jgroups.diagnostics}"
          external_addr="{xsite.address}"
          external_port="{xsite.port}"

--- a/config-generator/src/test/java/org/infinispan/images/AbstractMainTest.java
+++ b/config-generator/src/test/java/org/infinispan/images/AbstractMainTest.java
@@ -249,11 +249,13 @@ abstract class AbstractMainTest {
    }
 
    private void testJGroupsTcp(boolean diagnosticsEnabled) throws Exception {
-      XmlAssert xml = generate("jgroups-diagnostics-tcp").infinispan();
+      XmlAssert xml = generate(diagnosticsEnabled ? "jgroups-diagnostics-tcp" : "jgroups-diagnostics-disabled-tcp").infinispan();
       String bindProperty = String.format("${jgroups.bind.address,jgroups.tcp.address:%s}", InetAddress.getLocalHost().getHostAddress());
       assertStack(xml, "i:TCP")
-            .haveAttribute("enable_diagnostics", Boolean.toString(true))
-            .haveAttribute("bind_addr", bindProperty);
+            .haveAttribute("enable_diagnostics", Boolean.toString(diagnosticsEnabled))
+            .haveAttribute("bind_addr", bindProperty)
+            .haveAttribute("bind_port", "${jgroups.bind.port,jgroups.tcp.port:7800}")
+            .haveAttribute("port_range", "0");
       assertStack(xml, "i:MPING");
    }
 
@@ -327,9 +329,14 @@ abstract class AbstractMainTest {
             .haveAttribute("site", "LON");
 
       XmlAssert relay = jgroupsRelay();
+      String bindProperty = String.format("${jgroups.relay.bind.address:%s}", InetAddress.getLocalHost().getHostAddress());
       relay.hasXPath("//j:config/j:TCP")
+            .haveAttribute("bind_addr", bindProperty)
+            .haveAttribute("bind_port", "${jgroups.relay.bind.port:7900}")
             .haveAttribute("external_addr", "lon-addr")
-            .haveAttribute("external_port", "7200");
+            .haveAttribute("external_port", "7200")
+            .haveAttribute("port_range", "0")
+            .haveAttribute("enable_diagnostics", Boolean.toString(false));
 
       relay.hasXPath("//j:config/j:TCPPING")
             .haveAttribute("initial_hosts", "lon-addr[7200],nyc-addr[7200]");
@@ -444,8 +451,13 @@ abstract class AbstractMainTest {
             .haveAttribute("name", "NYC");
 
       XmlAssert relay = jgroupsRelay();
+      String bindProperty = String.format("${jgroups.relay.bind.address:%s}", InetAddress.getLocalHost().getHostAddress());
       relay.hasXPath("//j:config/j:TUNNEL")
-            .haveAttribute("gossip_router_hosts", "lon-addr[7200],nyc-addr[7200]");
+            .haveAttribute("gossip_router_hosts", "lon-addr[7200],nyc-addr[7200]")
+            .haveAttribute("bind_addr", bindProperty)
+            .haveAttribute("bind_port", "${jgroups.relay.bind.port:7900}")
+            .haveAttribute("port_range", "0")
+            .haveAttribute("enable_diagnostics", Boolean.toString(false));
    }
 
    @Test

--- a/config-generator/src/test/resources/config/jgroups-diagnostics-disabled-tcp.yaml
+++ b/config-generator/src/test/resources/config/jgroups-diagnostics-disabled-tcp.yaml
@@ -1,0 +1,2 @@
+jgroups:
+  diagnostics: false


### PR DESCRIPTION
Two properties added to jgroups-relay.xml to allow customize the bind
address and port for cross-site traffic.

* "jgroups.relay.bind.address" to customize the bind address
* "jgroups.relay.bind.port" to customize the bind port